### PR TITLE
Use prismatic container instead of Benoit's one.

### DIFF
--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -1,4 +1,4 @@
-FROM bchabord/django-nginx:3
+FROM prismaticd/django-nginx:3
 
 EXPOSE 9808
 

--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -1,4 +1,4 @@
-FROM prismaticd/django-nginx:3
+FROM prismaticd/django-nginx:3.6
 
 EXPOSE 9808
 


### PR DESCRIPTION
This will indirectly change the base debian from jessie to stretch

Sticking with py3.6 for now instead of latest (3.7+) for compatibility with Django 1.11 LTS