### PR TITLE
Fix import + make cookiecutter tests fail on failure

### DIFF
--- a/tests.sh
+++ b/tests.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+# -e exit on non 0 return
+set -e
+# -u exit on undefined variables
+set -u
+# -x print command before running (note that enabling this makes the gitlab test fail emails less readable)
+#set -x
+# bubble up the non 0 on pipes
+set -o pipefail
+
 cwd=$(pwd)
 
 export DJANGO_SETTINGS_MODULE="project_name.settings.test"

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/urls.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/urls.py
@@ -5,8 +5,8 @@ from django.conf.urls import url, include
 from django.contrib import admin
 {% if cookiecutter.install_wagtail == "y" -%}
 from wagtail.admin import urls as wagtailadmin_urls
-from wagtail.core import urls as wagtail_urls{% endif %}
-from wagtail.documents import urls as wagtaildocs_urls
+from wagtail.core import urls as wagtail_urls
+from wagtail.documents import urls as wagtaildocs_urls{% endif %}
 
 from .apps.core.urls import core
 {%- if cookiecutter.install_allauth == "y" %}


### PR DESCRIPTION
Tests was erroring due to bad import but wasn't causing travis to fail (due to no `set -e`)

https://travis-ci.org/prismaticd/django-cookiecutter/builds/419931384