### PR TITLE
urls property returns (list_of_urls, app_namespace, instance_namespace)

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/apps/core/tests/test_views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/apps/core/tests/test_views.py
@@ -5,6 +5,6 @@ from django.urls import reverse
 class ViewTest(TestCase):
 
     def test_home_view(self):
-        response = self.client.get(reverse("core_app:home-page"))
+        response = self.client.get(reverse("core:home-page"))
 
         self.assertEqual(response.status_code, 200)

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/apps/core/urls.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/apps/core/urls.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 class CoreApp(object):
-    name = "core_app"
+    name = "core"
 
     def get_urls(self):
         urlpatterns = [url(r"$", HomePageView.as_view(), name="home-page")]
@@ -19,7 +19,8 @@ class CoreApp(object):
 
     @property
     def urls(self):
-        return self.get_urls(), "core_app", self.name
+        # as per django.contrib.admin.sites.AdminSite#urls
+        return self.get_urls(), "core", self.name
 
 
 core = CoreApp()

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/apps/myauth/urls.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/apps/myauth/urls.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 class AuthApp(object):
-    name = "myauth_app"
+    name = ""
 
     def get_urls(self):
         urlpatterns = [
@@ -44,8 +44,9 @@ class AuthApp(object):
 
     @property
     def urls(self):
+        # as per django.contrib.admin.sites.AdminSite#urls
         # no namespace for compatibility with django-allauth
-        return self.get_urls(), self.name, ""
+        return self.get_urls(), "", self.name
 
 
 myauth = AuthApp()

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/apps/myauth/views.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/apps/myauth/views.py
@@ -32,7 +32,7 @@ class MyPasswordChangeView(allauth_views.PasswordChangeView):
 
 class MyPasswordSetView(allauth_views.PasswordSetView):
     template_name = "password_set.html"
-    success_url = reverse_lazy("core_app:home-page")
+    success_url = reverse_lazy("core:home-page")
 
 
 class MyPasswordResetView(allauth_views.PasswordResetView):

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/apps/profile/urls.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/apps/profile/urls.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 class ProfileApp(object):
-    name = "profile_app"
+    name = "profile"
 
     def get_urls(self):
         urlpatterns = [url(r"^profile/$", views.MyProfileView.as_view(), name="edit")]
@@ -19,7 +19,8 @@ class ProfileApp(object):
 
     @property
     def urls(self):
-        return self.get_urls(), self.name, "profile"
+        # as per django.contrib.admin.sites.AdminSite#urls
+        return self.get_urls(), "profile", self.name
 
 
 profile = ProfileApp()


### PR DESCRIPTION
Updated for consistency, also changed core app's namespace to "core" instead of "core_app"

see equivalent line in Django AdminSite.urls: https://github.com/django/django/blob/master/django/contrib/admin/sites.py#L285