### PR TITLE
Remove test_debug + make test_sqlite non-staging/prod

### DIFF
--- a/{{cookiecutter.project_slug}}/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/.gitlab-ci.yml
@@ -94,6 +94,10 @@ test_sqlite:
   script:
     # --parallel speeds up sqlite tests but doesn't seems to help mysql much
     - ./entrypoint.sh test --parallel
+  except:
+    # no point in running vs sqlite for deployment environments
+    - staging
+    - prod
   tags:
     - linux
     - docker

--- a/{{cookiecutter.project_slug}}/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/.gitlab-ci.yml
@@ -85,25 +85,6 @@ test_main:
     paths:
       - coverage/
 
-test_debug:
-  # Check for issues that only cause failures when DEBUG=True (eg missing Django templates)
-  stage: test
-  services:
-    {% if cookiecutter.database_type == "mysql" -%}
-    - mysql:5.7
-    {% elif cookiecutter.database_type == "postgres" -%}
-    - postgres:latest
-    {% endif -%}
-    - redis:latest
-  image: $CONTAINER_TEST_IMAGE
-  script:
-    - ./entrypoint.sh test
-  tags:
-    - linux
-    - docker
-  variables:
-    DEBUG: 1
-
 test_sqlite:
   # Check for issues that only affect sqlite (to avoid breaking frontend dev environment)
   stage: test


### PR DESCRIPTION
since Django>2.1 will raise an exception on missing {% include %} templates, so test_debug is no longer needed.